### PR TITLE
FIX : New index count is calculating wrong.

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -594,7 +594,8 @@
 
 			this._offUpEvents();
 			// FIX : if newIndex > startIndex is always comes with +1
-			if (newIndex > startIndex)
+			var pull = (undefined !== this.option('group').pull && this.option('group').pull === 'clone') ? true : false;
+                    	if (newIndex > startIndex && pull)
 				newIndex--;
 			if (evt) {
 				evt.preventDefault();

--- a/Sortable.js
+++ b/Sortable.js
@@ -593,7 +593,9 @@
 			_off(el, 'dragstart', this._onDragStart);
 
 			this._offUpEvents();
-
+			// FIX : if newIndex > startIndex is always comes with +1
+			if (newIndex > startIndex)
+				newIndex--;
 			if (evt) {
 				evt.preventDefault();
 				evt.stopPropagation();


### PR DESCRIPTION
When we change the index of an element in sortable list to forward ( ex : 0 to 4 ) it always turns newIndex+1 ( ex : 5 instead of 4 ) but it works good when we move to backward in list. So if we check newIndex>startIndex then decrease the nexIndex -1 it gives right result.