### PR TITLE
fix nest ng-sortable bug

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -96,6 +96,8 @@
 							newIndex = evt.newIndex,
 							items = source.items();
 
+						if (el !== evt.target) { return }
+
 						if (el !== evt.from) {
 							var prevSource = getSource(evt.from),
 								prevItems = prevSource.items();


### PR DESCRIPTION
See also: http://jsbin.com/xecamoqaqo/1/

If you drag a sub item, the item will append to `$scope.items`, not sort in `item.elems`