### PR TITLE
fix index calculation to skip templates

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -949,8 +949,10 @@
 	 */
 	function _index(/**HTMLElement*/el) {
 		var index = 0;
-		while (el && (el = el.previousElementSibling) && (el.nodeName.toUpperCase() !== 'TEMPLATE')) {
-			index++;
+		while (el && (el = el.previousElementSibling)) {
+			if (el.nodeName.toUpperCase() !== 'TEMPLATE') {
+				index++;
+			}
 		}
 		return index;
 	}


### PR DESCRIPTION
Current index calculation aborts as soon as a `<template>` tag is visited. But I think it should just skip the `<template>` tag?

In this context, but not directly related to this PR: is it on purpose that the index calculation does not take the `draggable` option into account? 