### PR TITLE
Allow adding an item to an empty meteor collection

### DIFF
--- a/meteor/reactivize.js
+++ b/meteor/reactivize.js
@@ -152,7 +152,8 @@ Template.sortable.rendered = function () {
 		// Insert the new element at the end of the list and move it where it was dropped.
 		// We could insert it at the beginning, but that would lead to negative orders.
 		var sortSpecifier = {}; sortSpecifier[orderField] = -1;
-		event.data.order = templateInstance.collection.findOne({}, { sort: sortSpecifier, limit: 1 }).order + 1;
+		var endItem = templateInstance.collection.findOne({}, { sort: sortSpecifier, limit: 1 });
+		event.data.order = endItem ? endItem[orderField] + 1 : 1;
 		// TODO: this can obviously be optimized by setting the order directly as the arithmetic average, with the caveats described above
 		var newElementId = templateInstance.collection.insert(event.data);
 		event.data._id = newElementId;

--- a/meteor/reactivize.js
+++ b/meteor/reactivize.js
@@ -163,6 +163,31 @@ Template.sortable.rendered = function () {
 		} else {
 			// do nothing - inserted after the last element
 		}
+
+		// From: http://stackoverflow.com/questions/10716986/swap-2-html-elements-and-preserve-event-listeners-on-them
+		function swapElements(obj1, obj2) {
+			// create marker element and insert it where obj1 is
+			var temp = document.createElement("div");
+			obj1.parentNode.insertBefore(temp, obj1);
+
+			// move obj1 to right before obj2
+			obj2.parentNode.insertBefore(obj1, obj2);
+
+			// move obj2 to right before where obj1 used to be
+			temp.parentNode.insertBefore(obj2, temp);
+
+			// remove temporary marker node
+			temp.parentNode.removeChild(temp);
+		}
+
+		// We swap our cloned element with the dragged one to keep blaze
+		// information on the originally cloned element
+		// See bug: https://github.com/RubaXa/Sortable/issues/275
+		if (typeof(event.clone) !== 'undefined') {
+			swapElements(itemEl, event.clone);
+			itemEl = event.clone;
+		}
+
 		// remove the dropped HTMLElement from the list because we have inserted it in the collection, which will update the template
 		itemEl.parentElement.removeChild(itemEl);
 	};


### PR DESCRIPTION
Maybe best to be reviewed by @dandv.

Use case is for cloning from an existing collection into another, initially empty, collection.

In the previous code, collection.findOne() is undefined if we have an empty collection.  Attempting to access the order property results in an Exception.

In addition, we should probably use the [orderField] as opposed to the order property directly.

When adding to an empty collection, this code sets the initial position to be 1.  I'm not sure what your preferences are for collection ordering beginning at 0 or 1.