### PR TITLE
Don't join class names when removing classes after additions.

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -889,6 +889,8 @@
 		el.removeEventListener(event, fn, false);
 	}
 
+	/** @const */
+	var RSPACE = /\s+/g;
 
 	function _toggleClass(el, name, state) {
 		if (el) {
@@ -896,11 +898,8 @@
 				el.classList[state ? 'add' : 'remove'](name);
 			}
 			else {
-				var className = (' ' + el.className + ' ')
-					.replace(/\s+/g, ' ')
-					.replace(' ' + name + ' ', ' ')
-					.replace(/  /, ' ');
-				el.className = className + (state ? ' ' + name : '');
+				var className = (' ' + el.className + ' ').replace(RSPACE, ' ').replace(' ' + name + ' ', ' ');
+				el.className = (className + (state ? ' ' + name : '')).replace(RSPACE, ' ');
 			}
 		}
 	}

--- a/Sortable.js
+++ b/Sortable.js
@@ -896,7 +896,10 @@
 				el.classList[state ? 'add' : 'remove'](name);
 			}
 			else {
-				var className = (' ' + el.className + ' ').replace(/\s+/g, ' ').replace(' ' + name + ' ', '');
+				var className = (' ' + el.className + ' ')
+					.replace(/\s+/g, ' ')
+					.replace(' ' + name + ' ', ' ')
+					.replace(/  /, ' ');
 				el.className = className + (state ? ' ' + name : '');
 			}
 		}


### PR DESCRIPTION
When having existing classes (E), and we're removing the class (A), if another class (B) was added since the removed class (A) was initially added, the names of the previous classes are joined with the new class (E and B) without a separator space.

See http://jsbin.com/nohavapeju/2/edit?html,css,js,output

In IE9.