### PR TITLE
angular event callbacks hotfix

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -160,7 +160,7 @@
 					});
 
 					if (ngSortable && !/{|}/.test(ngSortable)) { // todo: ugly
-						angular.forEach(['sort', 'disabled', 'draggable', 'handle', 'animation'], function (name) {
+						angular.forEach(['sort', 'disabled', 'draggable', 'handle', 'animation', 'onStart', 'onEnd', 'onAdd', 'onUpdate', 'onRemove', 'onSort'], function (name) {
 							scope.$watch(ngSortable + '.' + name, function (value) {
 								if (value !== void 0) {
 									options[name] = value;


### PR DESCRIPTION
Hello, I know it's under the "ugly" marked block and pretty much a quick hotfix, but I believe the following documented way of having events callback for angular version isn't working otherwise. 
```
$scope.barConfig = {
            onSort: function (/** ngSortEvent */evt){
            }
        };
```
Thank you.