### PR TITLE
Add ghostClass on fallback and touch devices

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -445,6 +445,9 @@
 				_css(ghostEl, 'position', 'fixed');
 				_css(ghostEl, 'zIndex', '100000');
 
+				// Add ghostClass on fallback and touch devices
+				ghostEl.className = options.ghostClass;
+
 				rootEl.appendChild(ghostEl);
 
 				// Fixing dimensions.


### PR DESCRIPTION
The ghostClass was only added to the element being dragged.

However, the ghost element happened by the library didn't have the className.