### PR TITLE
remove evt.preventDefault(); when filtering events

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -303,7 +303,6 @@
 				});
 
 				if (filter) {
-					evt.preventDefault();
 					return; // cancel dnd
 				}
 			}


### PR DESCRIPTION
removing the evt.preventDefault() call in the filtering process correct the issue I found when combining html5 input range element in sortable list.
Correct issue: https://github.com/RubaXa/Sortable/issues/329