### PR TITLE
Update Sortable.js

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -447,7 +447,12 @@
 
 			if (activeGroup.pull == 'clone') {
 				cloneEl = dragEl.cloneNode(true);
-				cloneEl.shadowRoot.innerHTML = dragEl.shadowRoot.innerHTML; //copy shadow root for polymer templates
+				//if shadow-root exists, copy shadow root for polymer templates
+				if (dragEl.shadowRoot)
+			    	{
+			    		cloneEl.shadowRoot.innerHTML = dragEl.shadowRoot.innerHTML;
+			    	}
+				
 				_css(cloneEl, 'display', 'none');
 				rootEl.insertBefore(cloneEl, dragEl);
 			}

--- a/Sortable.js
+++ b/Sortable.js
@@ -447,6 +447,7 @@
 
 			if (activeGroup.pull == 'clone') {
 				cloneEl = dragEl.cloneNode(true);
+				cloneEl.shadowRoot.innerHTML = dragEl.shadowRoot.innerHTML; //copy shadow root for polymer templates
 				_css(cloneEl, 'display', 'none');
 				rootEl.insertBefore(cloneEl, dragEl);
 			}


### PR DESCRIPTION
For pull-mode = clone the shadow-root is not cloned, so the "removed" item loses its content.
With this change the shadow root is also cloned into the new element:

    cloneEl.shadowRoot.innerHTML = dragEl.shadowRoot.innerHTML;

This allows this mode to work with web templates / polymer.

Example:
http://jsbin.com/roqosiyune/1/edit?html,console,output

If you pull from List 4 you can observe that the source element gets turned into `null`