### PR TITLE
Adds ability to hide the ghost and child elements with ghostClass

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -486,6 +486,7 @@
 				_css(ghostEl, 'opacity', '0.8');
 				_css(ghostEl, 'position', 'fixed');
 				_css(ghostEl, 'zIndex', '100000');
+				_css(ghostEl, 'display', 'none');
 
 				rootEl.appendChild(ghostEl);
 


### PR DESCRIPTION
I  was adding `display: none;` to a child button of the draggable element. The button element itself would hide onDragStart but it's ghost would not. This fixes that and makes it so that the entire ghost or any of it's child elements can be hidden with the ghostClass