### PR TITLE
ng-sortable: support configuration constant

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -26,7 +26,8 @@
 
 	angular.module('ng-sortable', [])
 		.constant('version', '0.3.7')
-		.directive('ngSortable', ['$parse', function ($parse) {
+		.constant('ngSortableConfig', {})
+		.directive('ngSortable', ['$parse', 'ngSortableConfig', function ($parse, ngSortableConfig) {
 			var removed,
 				nextSibling;
 
@@ -67,7 +68,7 @@
 				link: function (scope, $el, attrs) {
 					var el = $el[0],
 						ngSortable = attrs.ngSortable,
-						options = scope.$eval(ngSortable) || {},
+						options = angular.extend({}, ngSortableConfig, scope.$eval(ngSortable)),
 						source = getSource(el),
 						sortable
 					;

--- a/st/app.js
+++ b/st/app.js
@@ -148,6 +148,9 @@
 
 	// Angular example
 	angular.module('todoApp', ['ng-sortable'])
+		.constant('ngSortableConfig', {onEnd: function() {
+			console.log('default onEnd()');
+		}})
 		.controller('TodoController', ['$scope', function ($scope) {
 			$scope.todos = [
 				{text: 'learn angular', done: true},


### PR DESCRIPTION
This is a nice feature to provide sortable defaults in angular-way.

For example [angular-ui](https://github.com/angular-ui/bootstrap) supports configuring by the same way.