### PR TITLE
added option in the angular module for disabling syncing to the JS

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -139,12 +139,12 @@
 							scope.$apply();
 						},
 						onAdd: function (/**Event*/evt) {
-							_sync(evt);
+							(options.skipSync === true) || _sync(evt);
 							_emitEvent(evt, removed);
 							scope.$apply();
 						},
 						onUpdate: function (/**Event*/evt) {
-							_sync(evt);
+							(options.skipSync === true) || _sync(evt);
 							_emitEvent(evt);
 						},
 						onRemove: function (/**Event*/evt) {


### PR DESCRIPTION
This is useful when the developer wants to implement the JS persistence logic on his own. I changed it because I needed the following in my project.
- I have an attribute called position, which holds each item position (1,2...)
- then angular can use it to sort the list, without ever changing the order of the array elements, from this:

```js
myArray = [
  {id: 100, name: "Alice", position: 1},
  {id: 200, name: "Bob", position: 2},
  {id: 300, name: "Charlie", position: 3}
]
```

to this:
```js
myArray = [
  {id: 100, name: "Alice", position: 1},
  {id: 200, name: "Bob", position: 3},
  {id: 300, name: "Charlie", position: 2}
]
```

That works well for me, because with angular I can do:
```html
<div ng-repeat="object in array | orderBy:'position'>{{object.name}}</div>
```

```js
$scope.sortableOptions = {
    ...
    skipSync: true
}
```