### PR TITLE
ng-sortable: add prefix to version constant

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -25,7 +25,7 @@
 
 
 	angular.module('ng-sortable', [])
-		.constant('version', '0.3.7')
+		.constant('ngSortableVersion', '0.3.7')
 		.directive('ngSortable', ['$parse', function ($parse) {
 			var removed,
 				nextSibling;


### PR DESCRIPTION
Now this constant is global and can be overridden any another angular lib.

Also, I don't see any purpose to keep this constant at all