### PR TITLE
Correctly match multiple class names

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -885,7 +885,7 @@
 			selector = selector.split('.');
 
 			var tag = selector.shift().toUpperCase(),
-				re = new RegExp('\\s(' + selector.join('|') + ')\\s', 'g');
+				re = new RegExp('\\s(' + selector.join('|') + ')(?=\\s)', 'g');
 
 			do {
 				if (


### PR DESCRIPTION
Assume that `el.className === "foo bar"`
Assume that your selector is `"DIV.foo.bar"`

`(' ' + el.className + ' ').match(re)` will only have one match - `" foo "` - because the `"\\s"` trailing character on `"foo"` prevents `" bar "` from being matched

EZ fix is just to make sure the trailing whitespace is not consumed by the regex