### PR TITLE
Correctly match multiple class names

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -885,7 +885,7 @@
 			selector = selector.split('.');
 
 			var tag = selector.shift().toUpperCase(),
-				re = new RegExp('\\s(' + selector.join('|') + ')\\s', 'g');
+				re = new RegExp('\\s(' + selector.join('|') + ')(?=\\s)', 'g');
 
 			do {
 				if (


### PR DESCRIPTION
`_closest()` attempts to matching elements, supporting a very limited subset of CSS selectors.  It is clear from the code that support is expected for an option *element name* any number of *class selectors* e.g. `"DIV.foo.bar"`

Assume that `el.className === "foo bar"`
Assume that your selector is `"DIV.foo.bar"`

`(' ' + el.className + ' ').match(re)` will only have one match - `" foo "` - because the `"\\s"` trailing character on `"foo"` prevents `" bar "` from being matched

EZ fix is just to make sure the trailing whitespace is not consumed by the regex