### PR TITLE
angular watch more options

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -166,7 +166,7 @@
 					});
 
 					angular.forEach([
-						'sort', 'disabled', 'draggable', 'handle', 'animation',
+						'sort', 'disabled', 'draggable', 'handle', 'animation', 'group', 'ghostClass', 'filter',
 						'onStart', 'onEnd', 'onAdd', 'onUpdate', 'onRemove', 'onSort'
 					], function (name) {
 						watchers.push(scope.$watch('ngSortable.' + name, function (value) {


### PR DESCRIPTION
For some reason, if I attempt to use ng-sortable within a directive of my own, if certain options aren't being watched they won't work.  They do still work in other contexts, like a basic controller/template pair.

Anyway, adding them into the list of properties to watch solves the problem - though honestly I can't explain exactly why that is.

If there's a better way to fix this, cool - this is just what I did locally to get things working as expected.