### PR TITLE
fix click event for mobile devices and old browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,9 @@ var sortable = new Sortable(el, {
 	ghostClass: "sortable-ghost",  // Class name for the drop placeholder
 	dataIdAttr: 'data-id',
 	
-	/*
-	 ignore the HTML5 DnD behaviour and force the fallback to kick in
-	 - provide a more reliable cross-browser solution
-	 - grants the ability to display a different "dragged" element
-	*/
-	forcePolyfill: false,
+	forceFallback: false,  // ignore the HTML5 DnD behaviour and force the fallback to kick in
+	fallbackClass: "sortable-fallback"  // Class name for the cloned DOM Element when using forceFallback
+	fallbackOnBody: false  // Appends the cloned DOM Element into the Document's Body
 	
 	scroll: true, // or HTMLElement
 	scrollSensitivity: 30, // px, how near the mouse must be to an edge to start scrolling.
@@ -260,13 +257,13 @@ Sortable.create(list, {
 ---
 
 
-#### `forcePolyfill` option
-If set to `true`, the polyfill - or Fallback for non HTML5 Browser - will be used, even if we are using an HTML5 Browser.
+#### `forceFallback` option
+If set to `true`, the Fallback for non HTML5 Browser will be used, even if we are using an HTML5 Browser.
 This gives us the possiblity to test the behaviour for older Browsers even in newer Browser, or make the Drag 'n Drop feel more consistent between Desktop , Mobile and old Browsers.
 
-On top of that, the polyfill always generates a copy of that DOM Element in the Document's Body. This behaviour can be exploited to give us more control over the look of this 'dragged' Element.
+On top of that, the Fallback always generates a copy of that DOM Element and appends the class `fallbackClass` definied in the options. This behaviour controls the look of this 'dragged' Element.
 
-Demo: http://jsbin.com/zejimolava/edit?html,css,js,output
+Demo: http://jsbin.com/xinuyenabi/edit?html,css,js,output
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ var sortable = new Sortable(el, {
 	ghostClass: "sortable-ghost",  // Class name for the drop placeholder
 	dataIdAttr: 'data-id',
 	
+	/*
+	 ignore the HTML5 DnD behaviour and force the fallback to kick in
+	 - provide a more reliable cross-browser solution
+	 - grants the ability to display a different "dragged" element
+	*/
+	forcePolyfill: false,
+	
 	scroll: true, // or HTMLElement
 	scrollSensitivity: 30, // px, how near the mouse must be to an edge to start scrolling.
 	scrollSpeed: 10, // px
@@ -248,6 +255,18 @@ Sortable.create(list, {
   ghostClass: "ghost"
 });
 ```
+
+
+---
+
+
+#### `forcePolyfill` option
+If set to `true`, the polyfill - or Fallback for non HTML5 Browser - will be used, even if we are using an HTML5 Browser.
+This gives us the possiblity to test the behaviour for older Browsers even in newer Browser, or make the Drag 'n Drop feel more consistent between Desktop , Mobile and old Browsers.
+
+On top of that, the polyfill always generates a copy of that DOM Element in the Document's Body. This behaviour can be exploited to give us more control over the look of this 'dragged' Element.
+
+Demo: http://jsbin.com/zejimolava/edit?html,css,js,output
 
 
 ---

--- a/Sortable.js
+++ b/Sortable.js
@@ -45,6 +45,8 @@
 		tapEvt,
 		touchEvt,
 
+		moved,
+
 		/** @const */
 		RSPACE = /\s+/g,
 
@@ -442,6 +444,8 @@
 
 				touchEvt = touch;
 
+				moved = true;
+
 				_css(ghostEl, 'webkitTransform', translate3d);
 				_css(ghostEl, 'mozTransform', translate3d);
 				_css(ghostEl, 'msTransform', translate3d);
@@ -682,9 +686,10 @@
 			this._offUpEvents();
 
 			if (evt) {
-				evt.preventDefault();
-				!options.dropBubble && evt.stopPropagation();
-
+				if(moved) {
+					evt.preventDefault();
+					!options.dropBubble && evt.stopPropagation();
+				}
 				ghostEl && ghostEl.parentNode.removeChild(ghostEl);
 
 				if (dragEl) {
@@ -741,6 +746,8 @@
 
 				tapEvt =
 				touchEvt =
+
+				moved =
 
 				lastEl =
 				lastCSS =

--- a/Sortable.js
+++ b/Sortable.js
@@ -1021,17 +1021,19 @@
 			onMoveFn = sortable.options.onMove,
 			retVal;
 
+		evt = document.createEvent('Event');
+		evt.initEvent('move', true, true);
+
+		evt.to = toEl;
+		evt.from = fromEl;
+		evt.dragged = dragEl;
+		evt.draggedRect = dragRect;
+		evt.related = targetEl || toEl;
+		evt.relatedRect = targetRect || toEl.getBoundingClientRect();
+
+		fromEl.dispatchEvent(evt);
+
 		if (onMoveFn) {
-			evt = document.createEvent('Event');
-			evt.initEvent('move', true, true);
-
-			evt.to = toEl;
-			evt.from = fromEl;
-			evt.dragged = dragEl;
-			evt.draggedRect = dragRect;
-			evt.related = targetEl || toEl;
-			evt.relatedRect = targetRect || toEl.getBoundingClientRect();
-
 			retVal = onMoveFn.call(sortable, evt);
 		}
 

--- a/Sortable.js
+++ b/Sortable.js
@@ -179,7 +179,9 @@
 			dragoverBubble: false,
 			dataIdAttr: 'data-id',
 			delay: 0,
-			forcePolyfill: false
+			forceFallback: false,
+			fallbackClass: 'sortable-fallback',
+			fallbackOnBody: false
 		};
 
 
@@ -364,7 +366,7 @@
 
 				this._onDragStart(tapEvt, 'touch');
 			}
-			else if (!supportDraggable || this.options.forcePolyfill) {
+			else if (!supportDraggable || this.options.forceFallback) {
 				this._onDragStart(tapEvt, true);
 			}
 			else {
@@ -463,6 +465,9 @@
 
 				ghostEl = dragEl.cloneNode(true);
 
+				_toggleClass(ghostEl, this.options.ghostClass, false);
+				_toggleClass(ghostEl, this.options.fallbackClass, true);
+
 				_css(ghostEl, 'top', rect.top - parseInt(css.marginTop, 10));
 				_css(ghostEl, 'left', rect.left - parseInt(css.marginLeft, 10));
 				_css(ghostEl, 'width', rect.width);
@@ -471,7 +476,7 @@
 				_css(ghostEl, 'position', 'fixed');
 				_css(ghostEl, 'zIndex', '100000');
 
-				document.body.appendChild(ghostEl);
+				this.options.fallbackOnBody && document.body.appendChild(ghostEl) || rootEl.appendChild(ghostEl);
 
 				// Fixing dimensions.
 				ghostRect = ghostEl.getBoundingClientRect();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sortablejs",
   "exportName": "Sortable",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "devDependencies": {
     "grunt": "*",
     "grunt-version": "*",

--- a/react-sortable-mixin.js
+++ b/react-sortable-mixin.js
@@ -34,7 +34,8 @@
 		onUpdate: 'handleUpdate',
 		onRemove: 'handleRemove',
 		onSort: 'handleSort',
-		onFilter: 'handleFilter'
+		onFilter: 'handleFilter',
+		onMove: 'handleMove'
 	};
 
 
@@ -90,7 +91,7 @@
 
 
 			// Bind callbacks so that "this" refers to the component
-			'onStart onEnd onAdd onSort onUpdate onRemove onFilter'.split(' ').forEach(function (/** string */name) {
+			'onStart onEnd onAdd onSort onUpdate onRemove onFilter onMove'.split(' ').forEach(function (/** string */name) {
 				copyOptions[name] = function (evt) {
 					if (name === 'onStart') {
 						_nextSibling = evt.item.nextElementSibling;


### PR DESCRIPTION
fix for #411 #250 and #436
as well as #387
and #146 #393

**added forcePolyfill option.**
 - forcePolyfill is made to make cross-browser testing more easy.
 - forcePolyfill provides a reliable, consistent cross-browser Solution for
Sortable.
 - forcePolyfill gives us the possibility to change the way "dragged items"
lok like.