### PR TITLE
Fix example for filtering in README.md (and jsbin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Sortable.create(list, {
 	filter: ".js-remove, .js-edit",
 	onFilter: function (evt) {
 		var item = evt.item,
-			ctrl = evt.target;
+			ctrl = evt.to;
 
 		if (Sortable.utils.is(ctrl, ".js-remove")) {  // Click on remove button
 			item.parentNode.removeChild(item); // remove sortable item


### PR DESCRIPTION
In the example for filtering, `evt.target` is null, so you cannot differentiate between the delete and edit buttons.  `ctrl` should instead be set to `evt.to`.  

The [example from the article](http://jsbin.com/yexine/6/edit?html,js) for filtering should also be edited. Currently, clicking the x brings up the edit dialog because only the default "else" behavior is being followed.