### PR TITLE
added proper browserify support for ng-sortable

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -5,11 +5,15 @@
 (function (factory) {
 	'use strict';
 
-	if (window.angular && window.Sortable) {
-		factory(angular, Sortable);
-	}
-	else if (typeof define === 'function' && define.amd) {
+	if (typeof define === 'function' && define.amd) {
 		define(['angular', './Sortable'], factory);
+	}
+	else if (typeof module != "undefined" && typeof module.exports != "undefined") {
+		factory(require('angular'), require('./Sortable'));
+		module.exports = 'ng-sortable';
+	}
+	else if (window.angular && window.Sortable) {
+		factory(angular, Sortable);
 	}
 })(function (angular, Sortable) {
 	'use strict';


### PR DESCRIPTION
previously, it was impossible* to use `ng-sortable` via browserify because of weird factory construct

this PR fixes that (one only needs to require `sortablejs/ng-sortable`)