### PR TITLE
Allow Mongo.ObjectIDs in addition to random String IDs in Server-side method call

### DIFF
--- a/meteor/methods-server.js
+++ b/meteor/methods-server.js
@@ -21,7 +21,7 @@ Meteor.methods({
 			throw new Meteor.Error(403, 'Collection <' + collectionName + '> is not Sortable. Please add it to Sortable.collections in server code.');
 		}
 
-		check(ids, [String]);
+		check(ids, [ Match.OneOf(String, Mongo.Collection.ObjectID) ]);
 		check(sortField, String);
 		check(incDec, Number);
 		var selector = {_id: {$in: ids}}, modifier = {$inc: {}};

--- a/meteor/methods-server.js
+++ b/meteor/methods-server.js
@@ -21,7 +21,7 @@ Meteor.methods({
 			throw new Meteor.Error(403, 'Collection <' + collectionName + '> is not Sortable. Please add it to Sortable.collections in server code.');
 		}
 
-		check(ids, [ Match.OneOf(String, Mongo.Collection.ObjectID) ]);
+		check(ids, [ Match.OneOf(String, Mongo.ObjectID) ]);
 		check(sortField, String);
 		check(incDec, Number);
 		var selector = {_id: {$in: ids}}, modifier = {$inc: {}};


### PR DESCRIPTION
In the Sortable Meteor support here: https://github.com/RubaXa/Sortable/blob/master/meteor/methods-server.js#L24
Sortable is assuming in this check that Mongo _ids are Strings. However, while Mongo _ids may be strings, they can also be objects of type `Mongo.ObjectID` Meteor explicitly supports both types: http://docs.meteor.com/#/full/mongo_collection

So to properly handle both cases the id check line in the server-side method call should be:
```js
 check(ids, [ Match.OneOf(String, Mongo.ObjectID) ]);
```

That is what this PR implements.