### PR TITLE
meteor: option to specify collection selector

### DIFF
--- a/meteor/README.md
+++ b/meteor/README.md
@@ -81,6 +81,20 @@ Template.myTemplate.helpers({
 });
 ```
 
+#### meteor specific options
+
+* `selector` - you can specify collection selector if your list operates only on subset of collection. Example:
+
+```js
+Template.myTemplate.helpers({
+   playerOptions: function() {
+      return {
+         selector: { city: 'San Francisco' }
+      }
+   }
+});
+```
+
 
 ## Events
 

--- a/meteor/reactivize.js
+++ b/meteor/reactivize.js
@@ -90,7 +90,7 @@ Template.sortable.created = function () {
 	 */
 	templateInstance.adjustOrders = function adjustOrders(itemId, orderPrevItem, orderNextItem) {
 		var orderField = templateInstance.options.sortField;
-		var selector = {}, modifier = {$set: {}};
+		var selector = templateInstance.options.selector || {}, modifier = {$set: {}};
 		var ids = [];
 		var startOrder = templateInstance.collection.findOne(itemId)[orderField];
 		if (orderPrevItem !== null) {


### PR DESCRIPTION
Add an option to specify selector in meteor helper. This way you can operate only on a subset of collection.
Otherwise `Sortable` operates on whole collection (everything that is published to client).