### PR TITLE
should only consider draggable items when calculate index

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -260,7 +260,7 @@
 			}
 
 			// get the index of the dragged element within its parent
-			oldIndex = _index(target);
+			oldIndex = _index(target, options.draggable);
 
 			// Check filter
 			if (typeof filter === 'function') {
@@ -727,7 +727,7 @@
 					_toggleClass(dragEl, this.options.ghostClass, false);
 
 					if (rootEl !== parentEl) {
-						newIndex = _index(dragEl);
+						newIndex = _index(dragEl, options.draggable);
 
 						if (newIndex != -1) {
 							// drag from one list and drop into another
@@ -747,7 +747,7 @@
 
 						if (dragEl.nextSibling !== nextEl) {
 							// Get the index of the dragged element within its parent
-							newIndex = _index(dragEl);
+							newIndex = _index(dragEl, options.draggable);
 							if (newIndex != -1) {
 								// drag & drop within the same list
 								_dispatchEvent(this, rootEl, 'update', dragEl, rootEl, oldIndex, newIndex);
@@ -1115,16 +1115,21 @@
 	/**
 	 * Returns the index of an element within its parent
 	 * @param el
+	 * @param selector
 	 * @returns {number}
 	 * @private
 	 */
-	function _index(/**HTMLElement*/el) {
+	function _index(/**HTMLElement*/el, /**String*/selector) {
 		if (!el || !el.parentNode) {
 			return -1;
 		}
 		var index = 0;
+		var className = typeof selector === 'undefined' || selector === '>*' ? ' ' : selector.replace('.', '');
 		while (el && (el = el.previousElementSibling)) {
 			if (el.nodeName.toUpperCase() !== 'TEMPLATE') {
+				if ((' ' + el.className + ' ').replace(/[\t\r\n\f]/g, ' ').indexOf(className) < 0) {
+					continue;
+				}
 				index++;
 			}
 		}


### PR DESCRIPTION
In `_index` function, detect if given class is a draggable item class.