### PR TITLE
Remove dependency on internal angular method ($el.scope()) (issue #255)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,15 +302,15 @@ Demo: http://jsbin.com/naduvo/1/edit?html,js,output
 
 ```html
 <div ng-app="myApp" ng-controller="demo">
-	<ul ng-sortable>
+	<ul ng-sortable ng-model="items">
 		<li ng-repeat="item in items">{{item}}</li>
 	</ul>
 
-	<ul ng-sortable="{ group: 'foobar' }">
+	<ul ng-sortable="{ group: 'foobar' }" ng-model="foo">
 		<li ng-repeat="item in foo">{{item}}</li>
 	</ul>
 
-	<ul ng-sortable="barConfig">
+	<ul ng-sortable="barConfig" ng-model="bar">
 		<li ng-repeat="item in bar">{{item}}</li>
 	</ul>
 </div>


### PR DESCRIPTION
Fix #255 Drag and drop gives an error with Angular 1.3.* when you have debugInfo disabled.

[Plunker](http://jsbin.com/lugilujoro/1/edit?html,js,console,output)

**Breaking change**
Now html markup require **ng-model** to be used with the ng-sortable
Example:
```html
<div ng-app="myApp" ng-controller="demo">
	<ul ng-sortable ng-model="items">
		<li ng-repeat="item in items">{{item}}</li>
	</ul>

	<ul ng-sortable="{ group: 'foobar' }" ng-model="foo">
		<li ng-repeat="item in foo">{{item}}</li>
	</ul>

	<ul ng-sortable="barConfig" ng-model="bar">
		<li ng-repeat="item in bar">{{item}}</li>
	</ul>
</div>
```