### PR TITLE
knockout-sortable.js remove viewmodel reference to dom element.

### DIFF
--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -36,11 +36,11 @@
                 }.bind(undefined, e, viewModel, allBindings, options[e]);
         });
 
-        viewModel._sortable = Sortable.create(element, options);
+        sortableElement = Sortable.create(element, options);
 
         //Destroy the sortable if knockout disposes the element it's connected to
         ko.utils.domNodeDisposal.addDisposeCallback(element, function () {
-            viewModel._sortable.destroy();
+            sortableElement.destroy();
         });
         return ko.bindingHandlers.template.init(element, valueAccessor);
     },

--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -36,7 +36,7 @@
                 }.bind(undefined, e, viewModel, allBindings, options[e]);
         });
 
-        sortableElement = Sortable.create(element, options);
+        var sortableElement = Sortable.create(element, options);
 
         //Destroy the sortable if knockout disposes the element it's connected to
         ko.utils.domNodeDisposal.addDisposeCallback(element, function () {


### PR DESCRIPTION
Use closure local variable instead of attaching the element to viewmodel. This is to prevent error caused by bound dom element as in issue 559.
https://github.com/RubaXa/Sortable/issues/559