### PR TITLE
Added Browserify support for ng-sortable

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -5,11 +5,16 @@
 (function (factory) {
 	'use strict';
 
-	if (window.angular && window.Sortable) {
-		factory(angular, Sortable);
-	}
-	else if (typeof define === 'function' && define.amd) {
+	if (typeof define === 'function' && define.amd) {
 		define(['angular', './Sortable'], factory);
+	}
+	else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
+		require('angular');
+		factory(angular, require('./Sortable'));
+		module.exports = 'ng-sortable';
+	}
+	else if (window.angular && window.Sortable) {
+		factory(angular, Sortable);
 	}
 })(function (angular, Sortable) {
 	'use strict';


### PR DESCRIPTION
This change allows `ng-sortable.js` to work with Browserify (see closed PR #471). It works on my Angular app that uses Browserify to bundle the JS. To use, just `require('Sortable/ng-sortable');`