### PR TITLE
Bugfix in jquery.binding.js

### DIFF
--- a/jquery.binding.js
+++ b/jquery.binding.js
@@ -28,7 +28,7 @@
 	 */
 	$.fn.sortable = function (options) {
 		var retVal;
-
+		var callArgs = arguments;
 		this.each(function () {
 			var $el = $(this),
 				sortable = $el.data('sortable');
@@ -47,10 +47,10 @@
 					$el.removeData('sortable');
 				}
 				else if (typeof sortable[options] === 'function') {
-					retVal = sortable[options].apply(sortable, [].slice.call(arguments, 1));
+					retVal = sortable[options].apply(sortable, [].slice.call(callArgs, 1));
 				}
 				else if (options in sortable.options) {
-					retVal = sortable.option.apply(sortable, arguments);
+					retVal = sortable.option.apply(sortable, callArgs);
 				}
 			}
 		});


### PR DESCRIPTION
I have found a bug in the jquery binding. The arguments variable which was used to pass the function arguments to apply(...) is coming from the $.each handler function, and therefore doesn't contain the actual function call arguments.
This patch should fix the bug.