### PR TITLE
Add `getContainer` option for better react version support

### DIFF
--- a/react-sortable-mixin.js
+++ b/react-sortable-mixin.js
@@ -35,7 +35,11 @@
 		onRemove: 'handleRemove',
 		onSort: 'handleSort',
 		onFilter: 'handleFilter',
-		onMove: 'handleMove'
+		onMove: 'handleMove',
+		getContainer: function(component){
+			/** @namespace this.refs — http://facebook.github.io/react/docs/more-about-refs.html */
+			return (component.refs[options.ref] || component).getDOMNode()
+		}
 	};
 
 
@@ -132,7 +136,7 @@
 
 
 			/** @namespace this.refs — http://facebook.github.io/react/docs/more-about-refs.html */
-			this._sortableInstance = Sortable.create((this.refs[options.ref] || this).getDOMNode(), copyOptions);
+			this._sortableInstance = Sortable.create(copyOptions.getContainer(this), copyOptions);
 		},
 
 		componentWillReceiveProps: function (nextProps) {


### PR DESCRIPTION
Sorry if this fails CI or something..I wrote this in the github editor, since its simple. I can be a more thorough a bit later if you'd like.

react 0.14 deprecates .getDOMNode() so this PR maintains the current default but allows it to be configured, effectively removing the version specific React dependence.

Thanks for the great library!