### PR TITLE
Fix to knockout sorting when dragging item index 1 to 0.

### DIFF
--- a/knockout-sortable.js
+++ b/knockout-sortable.js
@@ -84,9 +84,11 @@
                     newIndex = e.newIndex;
 
                 if (e.item.previousElementSibling)
+                {
                     newIndex = fromArray.indexOf(ko.dataFor(e.item.previousElementSibling));
-                if (originalIndex > newIndex)
-                    newIndex = newIndex + 1;
+                    if (originalIndex > newIndex)
+                        newIndex = newIndex + 1;
+                }                
 
                 //Remove sortables "unbound" element
                 e.item.parentNode.removeChild(e.item);


### PR DESCRIPTION
The items would not swap positions when you dragged item with index 1 to
the top of the stack at index 0.