### PR TITLE
avoid changing oldIndex by the parent container

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -269,6 +269,10 @@
 			if (!target) {
 				return;
 			}
+			
+			if (options.handle && !_closest(originalTarget, options.handle, el)) {
+				return;
+			}
 
 			// get the index of the dragged element within its parent
 			oldIndex = _index(target);
@@ -295,11 +299,6 @@
 					evt.preventDefault();
 					return; // cancel dnd
 				}
-			}
-
-
-			if (options.handle && !_closest(originalTarget, options.handle, el)) {
-				return;
 			}
 
 


### PR DESCRIPTION
should fix https://github.com/RubaXa/Sortable/issues/618 and https://github.com/RubaXa/Sortable/issues/597

oldIndex was changed first by with the item being dragged, but also by the drag event of the parent