### PR TITLE
avoid changing oldIndex by the parent container

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -269,6 +269,10 @@
 			if (!target) {
 				return;
 			}
+			
+			if (options.handle && !_closest(originalTarget, options.handle, el)) {
+				return;
+			}
 
 			// get the index of the dragged element within its parent
 			oldIndex = _index(target);
@@ -296,12 +300,6 @@
 					return; // cancel dnd
 				}
 			}
-
-
-			if (options.handle && !_closest(originalTarget, options.handle, el)) {
-				return;
-			}
-
 
 			// Prepare `dragstart`
 			this._prepareDragStart(evt, touch, target);


### PR DESCRIPTION
should fix #618 and #597

oldIndex was changed first by with the item being dragged, but also by the drag event of the parent (which should be avoided when we are not using the drag-handle)