### PR TITLE
fix bug about evt.oldIndex when set options.group

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -15,7 +15,7 @@
 		module.exports = factory();
 	}
 	else if (typeof Package !== "undefined") {
-		//Sortable = factory();  // export for Meteor.js
+		Sortable = factory();  // export for Meteor.js
 	}
 	else {
 		/* jshint sub:true */

--- a/Sortable.js
+++ b/Sortable.js
@@ -95,7 +95,7 @@
 					scrollEl = options.scroll;
 					scrollParentEl = rootEl;
 
-					if (scrollEl === true) {
+					if (scrollEl =_onDragOver== true) {
 						scrollEl = rootEl;
 
 						do {
@@ -606,7 +606,8 @@
 					else if (!canSort) {
 						rootEl.appendChild(dragEl);
 					}
-
+					//fix bug when cancel drag
+					parentEl = dragEl.parentNode;
 					return;
 				}
 

--- a/Sortable.js
+++ b/Sortable.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-
+/* global Sortable */
 (function (factory) {
 	"use strict";
 
@@ -15,7 +15,7 @@
 		module.exports = factory();
 	}
 	else if (typeof Package !== "undefined") {
-		Sortable = factory();  // export for Meteor.js
+		//Sortable = factory();  // export for Meteor.js
 	}
 	else {
 		/* jshint sub:true */

--- a/Sortable.js
+++ b/Sortable.js
@@ -95,7 +95,7 @@
 					scrollEl = options.scroll;
 					scrollParentEl = rootEl;
 
-					if (scrollEl =_onDragOver== true) {
+					if (scrollEl === true) {
 						scrollEl = rootEl;
 
 						do {

--- a/Sortable.js
+++ b/Sortable.js
@@ -258,8 +258,10 @@
 				target = (touch || evt).target,
 				originalTarget = target,
 				filter = options.filter;
-
-
+			// don't trigger start event when an element is been dragged, otherwise the evt.oldindex always wrong when set option.group.
+			if(dragEl){
+				return;
+			}
 			if (type === 'mousedown' && evt.button !== 0 || options.disabled) {
 				return; // only left button or enabled
 			}

--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -85,7 +85,8 @@
 							model: item || source[evt.newIndex],
 							models: source,
 							oldIndex: evt.oldIndex,
-							newIndex: evt.newIndex
+							newIndex: evt.newIndex,
+							orignalEvt:evt
 						});
 					}
 


### PR DESCRIPTION
don't trigger start event when an element is been dragged, otherwise the evt.oldindex always wrong when set options.group.