### PR TITLE
Fix for Issue #580 [Angular] Javascript error when moving items between two lists very fast #683

### DIFF
--- a/ng-sortable.js
+++ b/ng-sortable.js
@@ -132,7 +132,7 @@
 						return opts;
 					}, {
 						onStart: function (/**Event*/evt) {
-							nextSibling = evt.item.nextSibling;
+							nextSibling = evt.from === evt.item.parentNode ? evt.item.nextSibling : evt.clone.nextSibling;
 							_emitEvent(evt);
 							scope.$apply();
 						},


### PR DESCRIPTION
Sometimes evt.from is different from evt.item.parentNode because the item has been moved already so using evt.item.nextSibling won't work when doing evt.from.insertBefore, because nextSibling is not a child of evt.from.

So in those cases we use evt.clone.nextSibling instead.