### PR TITLE
fix bug about evt.oldIndex when set options.group

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -259,7 +259,7 @@
 				originalTarget = target,
 				filter = options.filter;
 			// don't trigger start event when an element is been dragged, otherwise the evt.oldindex always wrong when set option.group.
-			if(dragEl){
+			if (dragEl) {
 				return;
 			}
 			if (type === 'mousedown' && evt.button !== 0 || options.disabled) {

--- a/Sortable.js
+++ b/Sortable.js
@@ -258,8 +258,10 @@
 				target = (touch || evt).target,
 				originalTarget = target,
 				filter = options.filter;
-
-
+			// don't trigger start event when an element is been dragged, otherwise the evt.oldindex always wrong when set option.group.
+			if(dragEl){
+				return;
+			}
 			if (type === 'mousedown' && evt.button !== 0 || options.disabled) {
 				return; // only left button or enabled
 			}


### PR DESCRIPTION
don't trigger start event when an element is been dragged, otherwise the evt.oldindex always wrong when set options.group.