### PR TITLE
Allow event functions to be defined as functions AND strings.

### DIFF
--- a/react-sortable-mixin.js
+++ b/react-sortable-mixin.js
@@ -87,6 +87,9 @@
 
 				emitEvent = function (/** string */type, /** Event */evt) {
 					var method = options[type];
+					if (method && typeof method === "string") {
+						method = this[method];
+					}
 					method && typeof method === "function" && method.call(this, evt, this._sortableInstance);
 				}.bind(this);
 


### PR DESCRIPTION
The current behavior (in `master`) is to define the handling functions for events as strings. Default for `onSort` for example is `handleSort`. Commit 8cef762d11dbabb27e489727bcc8fd5dfe8d844d changed this behavior forcing handling functions to be defined as functions in the options. This breaks all existing code, resulting in a no-op even with the default options (which still define the default handlers as strings).

This commit restores previous behavior AND allows you to define your handlers as functions directly, if you’re so inclined.