### PR TITLE
React Mixin - Fixing check for existence of getDOMNode function

### DIFF
--- a/react-sortable-mixin.js
+++ b/react-sortable-mixin.js
@@ -140,7 +140,7 @@
 				}.bind(this);
 			}, this);
 
-			DOMNode = this.getDOMNode() ? (this.refs[options.ref] || this).getDOMNode() : this.refs[options.ref] || this;
+			DOMNode = typeof this.getDOMNode === 'function' ? (this.refs[options.ref] || this).getDOMNode() : this.refs[options.ref] || this;
 
 			/** @namespace this.refs — http://facebook.github.io/react/docs/more-about-refs.html */
 			this._sortableInstance = Sortable.create(DOMNode, copyOptions);


### PR DESCRIPTION
Fixing error: *Uncaught TypeError: this.getDOMNode is not a function*