### PR TITLE
Calling this[fn].bind requires extra check

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -255,7 +255,7 @@
 
 		// Bind all private methods
 		for (var fn in this) {
-			if (fn.charAt(0) === '_') {
+			if (fn.charAt(0) === '_' && typeof(this[fn].bind) === 'function') {
 				this[fn] = this[fn].bind(this);
 			}
 		}


### PR DESCRIPTION
It is not valid to assume that Sortable's **prototype contains what you expect it to**.

In my environment, Sortable is loaded by `requirejs`, and the **prototype is modified** in requirejs's loader callback by injecting a special `__moduleId__` property into the prototype, in a fashion like this:
```javascript
        requirejs.onResourceLoad = function(context, map, depArray) {
            context.defined[map.id].prototype.__moduleId__ = map.id;
        };
```
At [Sortable.js#L232](https://github.com/RubaXa/Sortable/blob/master/Sortable.js#L232) this effectively leads to trying to call `.bind` on a `String` object, resulting in `this[fn].bind is not a function` error.

There should be a smarter way to copy functions from the prototype, so far I can suggest an extra check for object type before calling `.bind`:
```javascript
if (fn.charAt(0) === '_' && typeof(this[fn].bind) === 'function') {
	this[fn] = this[fn].bind(this);
}
```