### PR TITLE
Replace Object.assign for IE support

### DIFF
--- a/Sortable.html
+++ b/Sortable.html
@@ -61,9 +61,9 @@
       var options = {}
       Object.keys(this.properties).forEach(function(key) {
         options[key] = this[key]
-      })
+      });
 
-      this.sortable = Sortable.create(this, Object.assign(options, {
+      var eventCallbacks = {
         onUpdate: function (e) {
           if (template) {
             template.splice("items", e.newIndex, 0, template.splice("items", e.oldIndex, 1)[0])
@@ -115,7 +115,13 @@
         onClone: function(e) {
           this.fire("clone", e)
         }
-      }))
+      };
+
+      Object.keys(eventCallbacks).forEach(function(name){
+        options[name] = eventCallbacks[name];
+      });
+      
+      this.sortable = Sortable.create(this, options);
     },
 
     detached: function() {


### PR DESCRIPTION
Object.assign [is not supported in IE](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign); README includes support for IE. 

Based on my [understanding of Object.assign](http://www.2ality.com/2014/01/object-assign.html), this should be equivalent.

Thanks @gutenye for the Polymer element!