### PR TITLE
Applying Sortable to a non-ol/ul with defaults causes all drops to appear at top

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -1180,7 +1180,7 @@
 
 		while (el && (el = el.previousElementSibling)) {
 			if (el.nodeName.toUpperCase() !== 'TEMPLATE'
-					&& _matches(el, selector)) {
+					&& (_matches(el, selector) || selector === '>*')) {
 				index++;
 			}
 		}


### PR DESCRIPTION
When initializing Sortable on an element other than ul/ol, the draggable option is defaulted to ">*". When an item is dropped, however, the index calculation uses _matches to find a textual match. This always returns false, causing _index to always return 0.

The provided change causes _index to also accept the default value.