### PR TITLE
Use raw Sortable.js for meteor app

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -14,7 +14,7 @@
 	else if (typeof module != "undefined" && typeof module.exports != "undefined") {
 		module.exports = factory();
 	}
-	else if (typeof Package !== "undefined") {
+	else if (typeof Package['rubaxa:sortable'] !== "undefined") {
 		Sortable = factory();  // export for Meteor.js
 	}
 	else {


### PR DESCRIPTION
I build app with meteor. I know there have package. But with complexity of my app, raw sortable.js suit me well

Without the change, Sortable will return `undefined` because Sortable see I use Sortable via package. The fact is not. So we should check the exact package name `[rubaxa:sortable]`, instead of `Package` alone

By this, the check will return `false` because I don't install `rubaxa:sortable`