### PR TITLE
provide minified versions of third party libraries

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,9 +30,13 @@ module.exports = function (grunt) {
 				banner: '/*! <%= pkg.exportName %> <%= pkg.version %> - <%= pkg.license %> | <%= pkg.repository.url %> */\n'
 			},
 			dist: {
-				files: {
-					'<%= pkg.exportName %>.min.js': ['<%= pkg.exportName %>.js']
-				}
+				files: (function (bowerFiles) {
+					var files = {};
+					bowerFiles.forEach(function (main) {
+						files[main.slice(0, -3) + '.min.js'] = [main];
+					});
+					return files;
+				})(grunt.file.readJSON('bower.json').main)
 			},
 			jquery: {
 				files: {}


### PR DESCRIPTION
I didn't add the minified versions to git as I feel that would be extra noise in this commit. I figure you add them in the release process anyway.

Might be worth a breaking change to create a dist folder and have the versions compiled there (min and un-min but not be the actual source).
