### PR TITLE
[Polymer component]Added method to re-initialize sortable

### DIFF
--- a/Sortable.html
+++ b/Sortable.html
@@ -61,8 +61,9 @@
     },
 
     detached: function() {
-      this.sortable.destroy()
+      this.destroy()
     },
+
 
     initialize: function() {
 
@@ -120,6 +121,12 @@
         }
       }))
 
+    },
+
+    destroy: function() {
+      if(this.sortable) {
+        this.sortable.destroy()
+      }
     },
 
     groupChanged             : function(value) { this.sortable && this.sortable.option("group", value) },

--- a/Sortable.html
+++ b/Sortable.html
@@ -55,6 +55,17 @@
       //       <span>hello</span>
       //       <template is="dom-if">
       //     <tempalte is="dom-repeat">
+
+      this.initialize();
+
+    },
+
+    detached: function() {
+      this.sortable.destroy()
+    },
+
+    initialize: function() {
+
       var templates = this.querySelectorAll("template[is='dom-repeat']")
       var template = templates[templates.length-1]
 
@@ -108,10 +119,7 @@
           this.fire("move", e)
         }
       }))
-    },
 
-    detached: function() {
-      this.sortable.destroy()
     },
 
     groupChanged             : function(value) { this.sortable && this.sortable.option("group", value) },


### PR DESCRIPTION
Currently it is not possible to re-initialize the sortable component after it's been destroyed. I've added a method and wrapped everything in the attached in there and instead I'm calling that method on attached.

Then it'll be possible to call $0.initialize(); on the component to re-enable sortable.

/edit:

Just realized perhaps the same thing should be done with detached and creating a method to destroy it, so did that as well.