### PR TITLE
Polymer registers an end-event by default, renamed onEnd eventname

### DIFF
--- a/Sortable.html
+++ b/Sortable.html
@@ -105,7 +105,7 @@
         },
 
         onEnd: e => {
-          this.fire("end", e)
+          this.fire("sort-end", e)
         },
 
         onSort: e => {


### PR DESCRIPTION
Polymer registers an end event by default in every component. I've renamed the event fired in OnEnd from end to sort-end. Using on-end on the component fired the event twice.