### PR TITLE
Remove framework-dependent scripts from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,7 @@
 {
   "name": "Sortable",
   "main": [
-    "Sortable.js",
-    "ng-sortable.js",
-    "knockout-sortable.js",
-    "react-sortable-mixin.js"
+    "Sortable.js"
   ],
   "homepage": "http://rubaxa.github.io/Sortable/",
   "authors": [


### PR DESCRIPTION
According to `bower.json` docs, the main array should contain only one file per filetype: https://github.com/bower/spec/blob/master/json.md#main

Having framework dependent javascripts listed in the `main` array is a problem for build tools relying on `bower.json`, because there's probably no project that includes of the different frameworks.