### PR TITLE
jquery.binding: fixed non-working widget method

### DIFF
--- a/jquery.binding.js
+++ b/jquery.binding.js
@@ -41,7 +41,7 @@
 
 			if (sortable) {
 				if (options === 'widget') {
-					return sortable;
+					retVal = sortable;
 				}
 				else if (options === 'destroy') {
 					sortable.destroy();


### PR DESCRIPTION
Hi,

`
  $("#list").sortable("widget"); // get Sortable instance
`

from the docs wasn't working.

It's obvious since the used `return` would only return from its `function` and the real returned thing was `this`.