### PR TITLE
Polymer: Don't use element splice method for interim state

### DIFF
--- a/Sortable.html
+++ b/Sortable.html
@@ -78,7 +78,7 @@
       this.sortable = Sortable.create(this, Object.assign(options, {
         onUpdate: e => {
           if (template) {
-            template.splice("items", e.newIndex, 0, template.splice("items", e.oldIndex, 1)[0])
+            template.splice("items", e.newIndex, 0, template.items.splice(e.oldIndex, 1)[0]);
           }
           this.fire("update", e)
         },


### PR DESCRIPTION
Using the `template.splice` command to remove the item from the array
causes an update to any bound components which tends to create issues.