### PR TITLE
Missing comma on fallbackOnBody and fallbackClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ var sortable = new Sortable(el, {
 	
 	forceFallback: false,  // ignore the HTML5 DnD behaviour and force the fallback to kick in
 	fallbackClass: "sortable-fallback"  // Class name for the cloned DOM Element when using forceFallback
-	fallbackOnBody: false  // Appends the cloned DOM Element into the Document's Body
+	fallbackOnBody: false,  // Appends the cloned DOM Element into the Document's Body
 	
 	scroll: true, // or HTMLElement
 	scrollSensitivity: 30, // px, how near the mouse must be to an edge to start scrolling.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ var sortable = new Sortable(el, {
 	dataIdAttr: 'data-id',
 	
 	forceFallback: false,  // ignore the HTML5 DnD behaviour and force the fallback to kick in
-	fallbackClass: "sortable-fallback"  // Class name for the cloned DOM Element when using forceFallback
+	fallbackClass: "sortable-fallback",  // Class name for the cloned DOM Element when using forceFallback
 	fallbackOnBody: false,  // Appends the cloned DOM Element into the Document's Body
 	
 	scroll: true, // or HTMLElement


### PR DESCRIPTION
Adding a comma after the following statement, will make the options section valid javascript.

`fallbackOnBody: false` to `fallbackOnBody: false,`