### PR TITLE
Fix Destroy workflow

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -813,9 +813,8 @@
 						this.save();
 					}
 				}
-
+				this._nulling();
 			}
-			this._nulling();
 		},
 
 		_nulling: function() {


### PR DESCRIPTION
Don't null object links (rootEl, dragEl, etc) on Destroy. There are scenarios where this causes ```Sortable.js:1096 Uncaught TypeError: Cannot read property 'dispatchEvent' of null```. For example, this happens on Angular when you drag items containing sub-Sortables between lists. When you drop an item, it naturally executes onDrop. At the same time it destroys its sub-list (a child Sortable), which also calls onDrop. The latter onDrop resets the links, and that breaks the workflow of the initial onDrop. 