### PR TITLE
to fix issue 580

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -610,7 +610,7 @@
 				}
 
 				_on(document, 'drop', this);
-				setTimeout(this._dragStarted, 0);
+				this._dragStarted();
 			}
 		},
 


### PR DESCRIPTION
3q for your great work for bring us this useful JavaScript library, When I use this library, I came acoss the same isuuse as [issue 580](https://github.com/RubaXa/Sortable/issues/580), and i read the Sortable.js, I found its because one of progresses is asynchronous，so when move too fast between two lists, this progress will be delay, and cause evt.item.parentNode doesn't equal to evt.from.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rubaxa/sortable/867)
<!-- Reviewable:end -->
