### PR TITLE
Make constructor work as a function

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -181,6 +181,8 @@
 		if (!(el && el.nodeType && el.nodeType === 1)) {
 			throw 'Sortable: `el` must be HTMLElement, and not ' + {}.toString.call(el);
 		}
+		
+		if (!(this instanceof Sortable)) return new Sortable(el, options);
 
 		this.el = el; // root element
 		this.options = options = _extend({}, options);


### PR DESCRIPTION
Hi @RubaXa!

There is a small change allowing for using Sortable as a function, not forcing it being a class. Like so:
```js
const createSortable = require('sortable');
createSortable(el);
```
Which is, like, the easiest API one can dream of, and you no more need `.create` static method, which is rather confusing than handy, due to ambiguity (the paranoidal thought what is the difference between `.create(el)` and `new Sortable(el)` forces looking up to code).