### PR TITLE
This allows us to use nested lists with different handles. Without it…

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -265,6 +265,10 @@
 				originalTarget = target,
 				filter = options.filter;
 
+			if (options.handle && !_closest(originalTarget, options.handle, el)) {
+				return;
+			}
+
 
 			if (type === 'mousedown' && evt.button !== 0 || options.disabled) {
 				return; // only left button or enabled
@@ -301,11 +305,6 @@
 					evt.preventDefault();
 					return; // cancel dnd
 				}
-			}
-
-
-			if (options.handle && !_closest(originalTarget, options.handle, el)) {
-				return;
 			}
 
 


### PR DESCRIPTION
This allows us to use nested lists with different handles. Without it onTapStart will be called for inner list, and then for parent list, resulting in wrong number in oldIndex variable. 

Surely much better way will be saving oldIndex in each instance of sortable, but this is a quick solution. 

Now, nested lists can be made with handle: 'my-parent-handle' and handle:'my-child-handle'