### PR TITLE
Prevent error in _off method on drop

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -826,7 +826,9 @@
 
 			if (this.nativeDraggable) {
 				_off(document, 'drop', this);
-				_off(el, 'dragstart', this._onDragStart);
+				if (el) { // Sortable could have been destroyed while dragging
+				    _off(el, 'dragstart', this._onDragStart);
+				}
 			}
 
 			this._offUpEvents();


### PR DESCRIPTION
Prevent error in _off method on drop when Sortable is manually destroyed during dragging (el === null)