### PR TITLE
"evt.to" doesn't change when the onEnd is called #983

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -889,7 +889,7 @@
 							newIndex = oldIndex;
 						}
 
-						_dispatchEvent(this, rootEl, 'end', dragEl, rootEl, oldIndex, newIndex);
+						_dispatchEvent(this, parentEl, 'end', dragEl, rootEl, oldIndex, newIndex);
 
 						// Save sorting
 						this.save();


### PR DESCRIPTION
According to the documentation, when the element dragging has ended, the "onEnd" method is called.

When the element is dragged between shared lists, the "evt.to" doesn't update with the new list.
