### PR TITLE
Add classes on dragover

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -911,7 +911,7 @@
 							newIndex = oldIndex;
 						}
 
-						_dispatchEvent(this, rootEl, 'end', dragEl, rootEl, oldIndex, newIndex);
+						_dispatchEvent(this, parentEl, 'end', dragEl, rootEl, oldIndex, newIndex);
 
 						// Save sorting
 						this.save();

--- a/Sortable.js
+++ b/Sortable.js
@@ -952,7 +952,6 @@
 			var type = evt.type;
 
 			switch (type) {
-				case 'dragover':
 				case 'dragenter':
 					if (dragEl) {
 						this._onDragOver(evt);
@@ -961,7 +960,13 @@
 					break;
 
 				case 'dragleave':
-					this._onDragLeave(evt);
+					if (evt.target.tagName.toLowerCase() === this.options.draggable) {
+						evt.preventDefault();
+						evt.stopPropagation();
+					}
+					else {
+						this._onDragLeave(evt);
+					}
 					break;
 
 				case 'drop':

--- a/Sortable.js
+++ b/Sortable.js
@@ -246,6 +246,8 @@
 			ghostClass: 'sortable-ghost',
 			chosenClass: 'sortable-chosen',
 			dragClass: 'sortable-drag',
+			validGroupClass: 'sortable-valid',
+			invalidGroupClass: 'sortable-invalid',
 			ignore: 'a, img',
 			filter: null,
 			animation: 0,
@@ -288,9 +290,10 @@
 		if (this.nativeDraggable) {
 			_on(el, 'dragover', this);
 			_on(el, 'dragenter', this);
+			_on(el, 'dragleave', this);
 		}
 
-		touchDragOverListeners.push(this._onDragOver);
+		touchDragOverListeners.push(this._onDragOver, this._onDragLeave);
 
 		// Restore sorting
 		options.store && this.sort(options.store.get(this));
@@ -666,6 +669,9 @@
 				) &&
 				(evt.rootEl === void 0 || evt.rootEl === this.el) // touch fallback
 			) {
+				_toggleClass(el, options.invalidGroupClass, false);
+				_toggleClass(el, options.validGroupClass, true);
+
 				// Smart auto-scrolling
 				_autoScroll(evt, options, this.el);
 
@@ -776,6 +782,20 @@
 					}
 				}
 			}
+			else {
+				_toggleClass(el, options.validGroupClass, false);
+				_toggleClass(el, options.invalidGroupClass, true);
+			}
+		},
+
+		_onDragLeave: function () {
+			var el = this.el,
+				options = this.options;
+
+			_toggleClass(el, options.invalidGroupClass, false);
+			_toggleClass(el, options.validGroupClass, false);
+
+			el = null;
 		},
 
 		_animate: function (prevRect, target) {
@@ -816,6 +836,8 @@
 		_onDrop: function (/**Event*/evt) {
 			var el = this.el,
 				options = this.options;
+
+			this._onDragLeave();
 
 			clearInterval(this._loopId);
 			clearInterval(autoScroll.pid);
@@ -929,14 +951,23 @@
 		handleEvent: function (/**Event*/evt) {
 			var type = evt.type;
 
-			if (type === 'dragover' || type === 'dragenter') {
-				if (dragEl) {
-					this._onDragOver(evt);
-					_globalDragOver(evt);
-				}
-			}
-			else if (type === 'drop' || type === 'dragend') {
-				this._onDrop(evt);
+			switch (type) {
+				case 'dragover':
+				case 'dragenter':
+					if (dragEl) {
+						this._onDragOver(evt);
+						_globalDragOver(evt);
+					}
+					break;
+
+				case 'dragleave':
+					this._onDragLeave(evt);
+					break;
+
+				case 'drop':
+				case 'dragend':
+					this._onDrop(evt);
+					break;
 			}
 		},
 
@@ -1051,6 +1082,7 @@
 			});
 
 			touchDragOverListeners.splice(touchDragOverListeners.indexOf(this._onDragOver), 1);
+			touchDragOverListeners.splice(touchDragOverListeners.indexOf(this._onDragLeave), 1);
 
 			this._onDrop();
 

--- a/st/app.css
+++ b/st/app.css
@@ -51,6 +51,10 @@ ul {
 	opacity: .2;
 }
 
+.sortable-invalid > * {
+	pointer-events: none;
+}
+
 #foo .sortable-drag {
 	background: #daf4ff;
 }


### PR DESCRIPTION
Use these options to add classes for valid & invalid groups.

```
sortableOptions = {
        group: {
            name: 'qux',
            put: function (to) {
                return to.el.children.length < 4;
            }
        },
        validGroupClass: 'myValidCLass', // default is "sortable-valid"
        invalidGroupClass: 'myInvalidClass', // default is "'sortable-invalid'
    };
```

Also, in order to make it work with react, I had to apply this fix too (which was declined before):
https://github.com/RubaXa/Sortable/pull/984
If I don't use that fix, the item disappears after is dropped.