### PR TITLE
Null check activeSortable so it is not passed along to checkPull

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -463,11 +463,11 @@
 			}
 
 			try {
-				if (document.selection) {					
-					// Timeout neccessary for IE9					
+				if (document.selection) {
+					// Timeout neccessary for IE9
 					setTimeout(function () {
 						document.selection.empty();
-					});					
+					});
 				} else {
 					window.getSelection().removeAllRanges();
 				}
@@ -663,7 +663,7 @@
 
 			moved = true;
 
-			if (activeGroup && !options.disabled &&
+			if (activeGroup && activeSortable && !options.disabled &&
 				(isOwner
 					? canSort || (revert = !rootEl.contains(dragEl)) // Reverting item into the original list
 					: (


### PR DESCRIPTION
We were running into issues in IE11 when dragging sortable elements from one container to another.  This seemed to be caused by activeSortable being null and passed along to activeGroup.checkPull.

The project in which we were experiencing this is quite large, so we were unable to quickly put together a small duplication of the issue.