### PR TITLE
Fix Issue #972

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -318,6 +318,12 @@
 				return;
 			}
 
+			// Don't trigger start event when clicking on an input field
+			var sender = (evt && evt.target) || (window.event && window.event.srcElement);
+			if (sender.nodeName == "INPUT") {
+				return;
+			}
+
 			if (type === 'mousedown' && evt.button !== 0 || options.disabled) {
 				return; // only left button or enabled
 			}


### PR DESCRIPTION
When clicking a text input while using Firefox, the input is not given focus.  We should not initiate a start event if the user is trying to give focus to an input field.

This change fixes issue #972 