### PR TITLE
Add checking for pointerdown type

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -322,7 +322,7 @@
 				return;
 			}
 
-			if (type === 'mousedown' && evt.button !== 0 || options.disabled) {
+			if (/mousedown|pointerdown/.test(type) && evt.button !== 0 || options.disabled) {
 				return; // only left button or enabled
 			}
 


### PR DESCRIPTION
The current code only checks for `mousedown` event. But there is a binding for `pointerdown` event.

Adding this checking will make sure `pointerdown` event does not pass if it's not triggered with left button.