### PR TITLE
Check if element exists while removing event listener

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -1191,12 +1191,16 @@
 
 
 	function _on(el, event, fn) {
-		el.addEventListener(event, fn, captureMode);
+		if (el) {
+			el.addEventListener(event, fn, captureMode);
+		}
 	}
 
 
 	function _off(el, event, fn) {
-		el.removeEventListener(event, fn, captureMode);
+		if (el) {
+			el.removeEventListener(event, fn, captureMode);
+		}
 	}
 
 


### PR DESCRIPTION
The reason I'm proposing this change is that sometimes we see in our log "Cannot read property 'removeEventListener' of null"

It can happen, that the element was removed before removing Event listener.