### PR TITLE
Fix bugs when dragged element has iframes

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -55,6 +55,7 @@
 
 		moved,
 		iframe_stash,
+		root_iframes,
 
 		/** @const */
 		R_SPACE = /\s+/g,
@@ -409,6 +410,16 @@
 							iframes[i].sortable_parentElement = iframes[i].parentElement;
 							iframes[i].sortable_nextElementSibling = iframes[i].nextElementSibling;
 							iframe_stash.appendChild(iframes[i]);
+						}
+					}
+					// stop iframes from stealing mouse events, to allow dragging on them
+					root_iframes = rootEl.querySelectorAll('iframe');
+					if (root_iframes && root_iframes.length)
+					{
+						for (var i = 0; i < root_iframes.length; i++)
+						{
+							root_iframes[i].sortable_pe = root_iframes[i].style['pointer-events'];
+							root_iframes[i].style['pointer-events'] = 'none';
 						}
 					}
 
@@ -917,6 +928,10 @@
 				}
 				iframe_stash = null;
 			}
+			// make iframes clickable again
+			for (var i = 0; i < root_iframes.length; i++)
+				root_iframes[i].style['pointer-events'] = root_iframes[i].sortable_pe;
+			root_iframes = [];
 
 			if (evt) {
 				if (moved) {

--- a/Sortable.js
+++ b/Sortable.js
@@ -54,6 +54,7 @@
 		touchEvt,
 
 		moved,
+		iframe_stash,
 
 		/** @const */
 		R_SPACE = /\s+/g,
@@ -397,6 +398,20 @@
 				dragEl.style['will-change'] = 'transform';
 
 				dragStartFn = function () {
+					// stash iframes because they prevent dragging
+					iframe_stash = null;
+					var iframes = dragEl.querySelectorAll('iframe');
+					if (iframes && iframes.length)
+					{
+						iframe_stash = document.createElement('x'); // intentionally not adding it to DOM
+						for (var i = 0; i < iframes.length; i++)
+						{
+							iframes[i].sortable_parentElement = iframes[i].parentElement;
+							iframes[i].sortable_nextElementSibling = iframes[i].nextElementSibling;
+							iframe_stash.appendChild(iframes[i]);
+						}
+					}
+
 					// Delayed drag has been triggered
 					// we can re-enable the events: touchmove/mousemove
 					_this._disableDelayedDrag();
@@ -888,6 +903,20 @@
 			}
 
 			this._offUpEvents();
+			
+			// unstash iframes
+			if (iframe_stash)
+			{
+				for (var i = 0; i < iframe_stash.children.length; i++)
+				{
+					var iframe = iframe_stash.children[i];
+					if (iframe.sortable_nextElementSibling)
+						iframe.sortable_parentElement.insertBefore(iframe, iframe.sortable_nextElementSibling)
+					else
+						iframe.sortable_parentElement.appendChild(iframe);
+				}
+				iframe_stash = null;
+			}
 
 			if (evt) {
 				if (moved) {


### PR DESCRIPTION
When the dragged element has iframes, it is undraggable, gets stuck, and other weird behaviors.
To fix it, on drag-start I take iframes out of the dragged element and out of DOM, and return them to place on drop.