### PR TITLE
Fix delayed dragging on Android

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -436,9 +436,9 @@
 					_on(ownerDocument, 'mouseup', _this._disableDelayedDrag);
 					_on(ownerDocument, 'touchend', _this._disableDelayedDrag);
 					_on(ownerDocument, 'touchcancel', _this._disableDelayedDrag);
-					_on(ownerDocument, 'mousemove', _this._disableDelayedDrag);
-					_on(ownerDocument, 'touchmove', _this._disableDelayedDrag);
-					_on(ownerDocument, 'pointermove', _this._disableDelayedDrag);
+					_on(ownerDocument, 'mousemove', _this._handleMovementDuringDelay);
+					_on(ownerDocument, 'touchmove', _this._handleMovementDuringDelay);
+					_on(ownerDocument, 'pointermove', _this._handleMovementDuringDelay);
 
 					_this._dragStartTimer = setTimeout(dragStartFn, options.delay);
 				} else {
@@ -449,6 +449,16 @@
 			}
 		},
 
+                _handleMovementDuringDelay: function(ev) {
+                    var dx = ev.clientX - this._lastX;
+                    var dy = ev.clientY - this._lastY;
+                    var rsquare = dx * dx + dy * dy;
+
+                    if (rsquare >= 1) {
+                        this._disableDelayedDrag();
+                    }
+                },
+
 		_disableDelayedDrag: function () {
 			var ownerDocument = this.el.ownerDocument;
 
@@ -456,9 +466,9 @@
 			_off(ownerDocument, 'mouseup', this._disableDelayedDrag);
 			_off(ownerDocument, 'touchend', this._disableDelayedDrag);
 			_off(ownerDocument, 'touchcancel', this._disableDelayedDrag);
-			_off(ownerDocument, 'mousemove', this._disableDelayedDrag);
-			_off(ownerDocument, 'touchmove', this._disableDelayedDrag);
-			_off(ownerDocument, 'pointermove', this._disableDelayedDrag);
+			_off(ownerDocument, 'mousemove', this._handleMovementDuringDelay);
+			_off(ownerDocument, 'touchmove', this._handleMovementDuringDelay);
+			_off(ownerDocument, 'pointermove', this._handleMovementDuringDelay);
 		},
 
 		_triggerDragStart: function (/** Event */evt, /** Touch */touch) {


### PR DESCRIPTION
After a recent update to Chrome WebView on Android, the web view
became hyper-sensitive to touches, reporting subpixel movements.
This led to premature cancellation of dragging.