### PR TITLE
Fix delayed dragging on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ var sortable = new Sortable(el, {
 	scrollSensitivity: 30, // px, how near the mouse must be to an edge to start scrolling.
 	scrollSpeed: 10, // px
 
+	moveThreshold: // Minimum pointer movement, in pixels, which cancels a long press gesture
+
 	setData: function (/** DataTransfer */dataTransfer, /** HTMLElement*/dragEl) {
 		dataTransfer.setData('Text', dragEl.textContent); // `dataTransfer` object of HTML5 DragEvent
 	},
@@ -385,6 +387,17 @@ Defines how near the mouse must be to an edge to start scrolling.
 #### `scrollSpeed` option
 The speed at which the window should scroll once the mouse pointer gets within the `scrollSensitivity` distance.
 
+
+---
+
+
+#### `moveThreshold` option
+On some Android systems (probably after [this](https://chromereleases.googleblog.com/2017/08/chrome-beta-for-android-update.html)
+update) Chrome Web View reports touch movement events with subpixel precision. This disrupts normal operation of the long press
+handling.
+
+The `moveThreshold` setting defines a radius in pixels around the `touchstart` position. Touch movements inside of that radius do not
+cancel the drag detection gesture.
 
 ---
 

--- a/Sortable.js
+++ b/Sortable.js
@@ -242,6 +242,7 @@
 			scroll: true,
 			scrollSensitivity: 30,
 			scrollSpeed: 10,
+			moveThreshold: 1,
 			draggable: /[uo]l/i.test(el.nodeName) ? 'li' : '>*',
 			ghostClass: 'sortable-ghost',
 			chosenClass: 'sortable-chosen',
@@ -432,9 +433,9 @@
 					_on(ownerDocument, 'mouseup', _this._disableDelayedDrag);
 					_on(ownerDocument, 'touchend', _this._disableDelayedDrag);
 					_on(ownerDocument, 'touchcancel', _this._disableDelayedDrag);
-					_on(ownerDocument, 'mousemove', _this._disableDelayedDrag);
-					_on(ownerDocument, 'touchmove', _this._disableDelayedDrag);
-					_on(ownerDocument, 'pointermove', _this._disableDelayedDrag);
+					_on(ownerDocument, 'mousemove', _this._handleMovementDuringDelay);
+					_on(ownerDocument, 'touchmove', _this._handleMovementDuringDelay);
+					_on(ownerDocument, 'pointermove', _this._handleMovementDuringDelay);
 
 					_this._dragStartTimer = setTimeout(dragStartFn, options.delay);
 				} else {
@@ -445,6 +446,17 @@
 			}
 		},
 
+                _handleMovementDuringDelay: function(ev) {
+                    var dx = ev.clientX - this._lastX;
+                    var dy = ev.clientY - this._lastY;
+                    var rSquare = dx * dx + dy * dy;
+                    var rSquareMove = this.options.moveThreshold * this.options.moveThreshold;
+
+                    if (rSquare >= rSquareMove) {
+                        this._disableDelayedDrag();
+                    }
+                },
+
 		_disableDelayedDrag: function () {
 			var ownerDocument = this.el.ownerDocument;
 
@@ -452,9 +464,9 @@
 			_off(ownerDocument, 'mouseup', this._disableDelayedDrag);
 			_off(ownerDocument, 'touchend', this._disableDelayedDrag);
 			_off(ownerDocument, 'touchcancel', this._disableDelayedDrag);
-			_off(ownerDocument, 'mousemove', this._disableDelayedDrag);
-			_off(ownerDocument, 'touchmove', this._disableDelayedDrag);
-			_off(ownerDocument, 'pointermove', this._disableDelayedDrag);
+			_off(ownerDocument, 'mousemove', this._handleMovementDuringDelay);
+			_off(ownerDocument, 'touchmove', this._handleMovementDuringDelay);
+			_off(ownerDocument, 'pointermove', this._handleMovementDuringDelay);
 		},
 
 		_triggerDragStart: function (/** Event */evt, /** Touch */touch) {


### PR DESCRIPTION
After a recent update to Chrome WebView on Android, the web view
became hyper-sensitive to touches, reporting subpixel movements.
This led to premature cancellation of dragging.