### PR TITLE
Use Element.matches for improved selector support

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -1427,15 +1427,11 @@
 
 	function _matches(/**HTMLElement*/el, /**String*/selector) {
 		if (el) {
-			selector = selector.split('.');
-
-			var tag = selector.shift().toUpperCase(),
-				re = new RegExp('\\s(' + selector.join('|') + ')(?=\\s)', 'g');
-
-			return (
-				(tag === '' || el.nodeName.toUpperCase() == tag) &&
-				(!selector.length || ((' ' + el.className + ' ').match(re) || []).length == selector.length)
-			);
+			if (el.matches) {
+				return el.matches(selector);
+			} else if (el.msMatchesSelector) {
+				return el.msMatchesSelector(selector);
+			}
 		}
 
 		return false;


### PR DESCRIPTION
This PR changes the _matches() function to use el.matches(), or el.msMatchesSelector() for IE9. The result is more flexible selector support for options such as `filter` and `draggable`, e.g. `.classA:not(.classB)`.
I believe this works with all browsers Sortable supports, but if not I can always add additional prefixed matchesSelector alternatives for older browsers or even fall back to the existing custom function if nothing else is supported.

Fixes #1219