### PR TITLE
(fix) Bind context to setTimeout

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -467,7 +467,7 @@
 					_on(ownerDocument, 'touchmove', _this._delayedDragTouchMoveHandler);
 					options.supportPointer && _on(ownerDocument, 'pointermove', _this._delayedDragTouchMoveHandler);
 
-					_this._dragStartTimer = setTimeout(dragStartFn, options.delay);
+					_this._dragStartTimer = setTimeout(dragStartFn, options.delay).bind(_this);
 				} else {
 					dragStartFn();
 				}

--- a/Sortable.js
+++ b/Sortable.js
@@ -467,7 +467,7 @@
 					_on(ownerDocument, 'touchmove', _this._delayedDragTouchMoveHandler);
 					options.supportPointer && _on(ownerDocument, 'pointermove', _this._delayedDragTouchMoveHandler);
 
-					_this._dragStartTimer = setTimeout(dragStartFn, options.delay).bind(_this);
+					_this._dragStartTimer = setTimeout(dragStartFn.bind(_this), options.delay);
 				} else {
 					dragStartFn();
 				}


### PR DESCRIPTION
# Description


There are reported issues with the option `delay` not working, specifically on mobile (see GitHub Issues [659], [981], [989], [1130], [1136]).

# Cause

A `dragStartFn` call loses its context because it is invoked by `setTimeout`.

# Solution

Bind the context.

### Note

I do not believe this is necessary for other `setTimeout` or `setInterval` calls because they meet one of the following criteria:

1. Their function calls do not require a context.
2. The correct context is already in scope by the variable `_this`.
3. Private functions already have their context bounded to them.


[659]: https://github.com/RubaXa/Sortable/issues/659
[981]: https://github.com/RubaXa/Sortable/issues/981
[989]: https://github.com/RubaXa/Sortable/issues/989
[1130]: https://github.com/RubaXa/Sortable/issues/1130
[1136]: https://github.com/RubaXa/Sortable/issues/1136