### PR TITLE
Added ID-Based Duplicate Protection for Cloning

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -264,7 +264,8 @@
 			disabled: false,
 			store: null,
 			handle: null,
-      scroll: true,
+			allowDuplicates: true,
+			scroll: true,
 			scrollSensitivity: 30,
 			scrollSpeed: 10,
 			draggable: /[uo]l/i.test(el.nodeName) ? 'li' : '>*',
@@ -819,6 +820,17 @@
 					}
 				}
 				else if (target && !target.animated && target !== dragEl && (target.parentNode[expando] !== void 0)) {
+					if (!options.allowDuplicates && el !== rootEl) {
+						var duplicates = el.querySelectorAll("#"+dragEl.id);
+						if (duplicates.length > 1) {
+							return;
+						}
+						if (duplicates.length == 1) {
+							if (!duplicates[0].classList.contains(options.ghostClass)) {
+								return;
+							}
+						}
+					}
 					if (lastEl !== target) {
 						lastEl = target;
 						lastCSS = _css(target);


### PR DESCRIPTION
It's an old closed issue that's been never resolved but I made a solution for #708. I added a new option, allowDuplicates, that is true by default and it preserves the default behaviour of the code. If this tag is set to false, then it checks if there is a conflicting ID in the potential new parent. If there is a such ID, it basically behaves like put = false for that specific grouping.