### PR TITLE
Modify the onChoose event firing order

### DIFF
--- a/Sortable.js
+++ b/Sortable.js
@@ -440,7 +440,7 @@
 
 					// Drag start event
 					_dispatchEvent(_this, rootEl, 'choose', dragEl, rootEl, rootEl, oldIndex);
-					
+
 					// Chosen item
 					_toggleClass(dragEl, options.chosenClass, true);
 				};

--- a/Sortable.js
+++ b/Sortable.js
@@ -435,14 +435,14 @@
 					// Make the element draggable
 					dragEl.draggable = _this.nativeDraggable;
 					
-					// Drag start event
-					_dispatchEvent(_this, rootEl, 'choose', dragEl, rootEl, rootEl, oldIndex);
-
-					// Chosen item
-					_toggleClass(dragEl, options.chosenClass, true);
-
 					// Bind the events: dragstart/dragend
 					_this._triggerDragStart(evt, touch);
+
+					// Drag start event
+					_dispatchEvent(_this, rootEl, 'choose', dragEl, rootEl, rootEl, oldIndex);
+					
+					// Chosen item
+					_toggleClass(dragEl, options.chosenClass, true);
 				};
 
 				// Disable "draggable"

--- a/Sortable.js
+++ b/Sortable.js
@@ -434,15 +434,15 @@
 
 					// Make the element draggable
 					dragEl.draggable = _this.nativeDraggable;
+					
+					// Drag start event
+					_dispatchEvent(_this, rootEl, 'choose', dragEl, rootEl, rootEl, oldIndex);
 
 					// Chosen item
 					_toggleClass(dragEl, options.chosenClass, true);
 
 					// Bind the events: dragstart/dragend
 					_this._triggerDragStart(evt, touch);
-
-					// Drag start event
-					_dispatchEvent(_this, rootEl, 'choose', dragEl, rootEl, rootEl, oldIndex);
 				};
 
 				// Disable "draggable"


### PR DESCRIPTION
How the onChoose event is fired before the sortable-chosen style is added, it should be able to do more fine control